### PR TITLE
Fix incorrect argparse types for --output and --material

### DIFF
--- a/objuvpacker.py
+++ b/objuvpacker.py
@@ -45,8 +45,8 @@ def guess_realpath(path):
 def main():
     parser = argparse.ArgumentParser(description="Naively pokes obj+mtls")
     parser.add_argument("obj", help="path to the .obj file")
-    parser.add_argument("-m", "--material", nargs=1, help="path to the .mtl file")
-    parser.add_argument("-o","--output", nargs=1, help="output name, used for image and folder")
+    parser.add_argument("-m", "--material", help="path to the .mtl file")
+    parser.add_argument("-o","--output", help="output name, used for image and folder")
     parser.add_argument("-a","--add", nargs="+", help="any additional images to pack")
 
     parser.add_argument('--no-crop', dest='crop', action='store_false', help="do not attempt to crop textures to just what is used")


### PR DESCRIPTION
Using `nargs=1` was wrong because that turns the argument into a list type,
so the below `output_name = args.output` would have `output_name` be a list,
not a file path string as intended.

Fixes crash:

      File "objuvpacker.py", line 110, in main
        outname = output_name+"_full.png"
    TypeError: can only concatenate list (not "str") to list